### PR TITLE
Py2 compatibility and file wildcards

### DIFF
--- a/conda2wheel/__init__.py
+++ b/conda2wheel/__init__.py
@@ -91,7 +91,8 @@ def copy_to_tempdir(condafile, wheel_dir):
 def fix_platform(wheel_dir):
     for wheel_file in glob(os.path.sep.join(
             [wheel_dir, '*'])):
-        new_wheel_file = wheel_file.replace('-any.', '-%s.' % (platform.machine()))
+        new_wheel_file = wheel_file.replace('-any.', '-%s_%s.' % (
+            platform.system().lower(), platform.machine()))
         new_wheel_file = new_wheel_file.replace('-py', '-cp')
         os.rename(wheel_file, new_wheel_file)
 

--- a/conda2wheel/__init__.py
+++ b/conda2wheel/__init__.py
@@ -96,4 +96,4 @@ def main():
         logging.basicConfig(level=logging.DEBUG)
 
     for condafile in condafiles:
-        copy_to_tempdir(args.condafile, args.wheel_dir)
+        copy_to_tempdir(condafile, args.wheel_dir)

--- a/conda2wheel/__init__.py
+++ b/conda2wheel/__init__.py
@@ -101,8 +101,10 @@ def copy_to_tempdir(condafile, wheel_dir):
 def fix_platform(wheel_dir):
     for wheel_file in glob(os.path.join(
             wheel_dir, '*.whl')):
+        _system = platform.system().lower()
+        _system = _system[:3] if _system == 'windows' else _system
         new_wheel_file = wheel_file.replace('-any.', '-%s_%s.' % (
-            platform.system().lower(), platform.machine().lower()))
+            _system, platform.machine().lower()))
         new_wheel_file = new_wheel_file.replace('-py', '-cp')
         os.rename(wheel_file, new_wheel_file)
 

--- a/conda2wheel/__init__.py
+++ b/conda2wheel/__init__.py
@@ -7,6 +7,7 @@ import tarfile
 import tempfile
 import logging
 from wheel.egg2wheel import egg2wheel, egg_info_re
+from glob import glob
 from distlib.metadata import Metadata
 
 logger = logging.getLogger(__name__)
@@ -89,8 +90,10 @@ def main():
     parser.add_argument('--debug', action="store_true")
     parser.add_argument('condafile')
     args = parser.parse_args()
+    condafiles = glob(args.condafile)
 
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)
 
-    copy_to_tempdir(args.condafile, args.wheel_dir)
+    for condafile in condafiles:
+        copy_to_tempdir(args.condafile, args.wheel_dir)

--- a/conda2wheel/__init__.py
+++ b/conda2wheel/__init__.py
@@ -102,7 +102,7 @@ def fix_platform(wheel_dir):
     for wheel_file in glob(os.path.join(
             wheel_dir, '*.whl')):
         new_wheel_file = wheel_file.replace('-any.', '-%s_%s.' % (
-            platform.system().lower(), platform.machine()))
+            platform.system().lower(), platform.machine().lower()))
         new_wheel_file = new_wheel_file.replace('-py', '-cp')
         os.rename(wheel_file, new_wheel_file)
 

--- a/conda2wheel/__init__.py
+++ b/conda2wheel/__init__.py
@@ -10,7 +10,6 @@ from wheel.egg2wheel import egg2wheel, egg_info_re
 from glob import glob
 from distlib.metadata import Metadata
 from distutils.archive_util import make_archive
-import platform
 
 from delocate import wheeltools
 
@@ -98,14 +97,10 @@ def copy_to_tempdir(condafile, wheel_dir):
             copy_to_condadir(condadir, condafile, wheel_dir, tmp)
 
 
-def fix_platform(wheel_dir):
+def fix_cpver(wheel_dir):
     for wheel_file in glob(os.path.join(
             wheel_dir, '*.whl')):
-        _system = platform.system().lower()
-        _system = _system[:3] if _system == 'windows' else _system
-        new_wheel_file = wheel_file.replace('-any.', '-%s_%s.' % (
-            _system, platform.machine().lower()))
-        new_wheel_file = new_wheel_file.replace('-py', '-cp')
+        new_wheel_file = wheel_file.replace('-py', '-cp')
         os.rename(wheel_file, new_wheel_file)
 
 
@@ -124,6 +119,6 @@ def main():
 
     for condafile in condafiles:
         copy_to_tempdir(condafile, args.wheel_dir)
-    fix_platform(args.wheel_dir)
+    fix_cpver(args.wheel_dir)
     if args.dll_files is not None and args.sub_path is not None:
         add_dlls(glob(args.dll_files), args.wheel_dir, args.sub_path)

--- a/conda2wheel/__init__.py
+++ b/conda2wheel/__init__.py
@@ -70,7 +70,6 @@ def copy_toplevels(egg, egg_dir):
 
 def copy_to_condadir(condadir, condafile, wheel_dir, tmp_dir):
     extract(condafile, condadir)
-
     for egg in find_eggifo(condadir):
         metadata = process_egg(egg)
         egg_name = os.path.basename(egg)
@@ -81,7 +80,7 @@ def copy_to_condadir(condadir, condafile, wheel_dir, tmp_dir):
         egg2wheel(egg_dir, os.path.join(os.getcwd(), wheel_dir))
 
 
-def copy_to_tempdir(condafile, wheel_dir):
+def copy_to_wheeldir(condafile, wheel_dir):
     if not hasattr(tempfile, 'TemporaryDirectory'):
         try:
             tmp = tempfile.mkdtemp()
@@ -118,7 +117,7 @@ def main():
         logging.basicConfig(level=logging.DEBUG)
 
     for condafile in condafiles:
-        copy_to_tempdir(condafile, args.wheel_dir)
-    fix_cpver(args.wheel_dir)
-    if args.dll_files is not None and args.sub_path is not None:
-        add_dlls(glob(args.dll_files), args.wheel_dir, args.sub_path)
+        copy_to_wheeldir(condafile, args.wheel_dir)
+    # fix_cpver(args.wheel_dir)
+    # if args.dll_files is not None and args.sub_path is not None:
+    #     add_dlls(glob(args.dll_files), args.wheel_dir, args.sub_path)

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ def _read(filename):
 requires = [
     "distlib",
     "wheel",
+    "delocate",
 ]
 
 points = {


### PR DESCRIPTION
Changes:

* Make conda2wheel Py2 compatible
* Added `glob` filename matching and multiple wheel via file wildcard conversion

See [here](https://ci.appveyor.com/project/pkittenis/ssh2-python/build/1.0.113/job/rq5xuow11dwfusm8) for a build with this code on Py2, using wildcard file pattern.

Thanks for the useful tool.